### PR TITLE
Import gpg keys before creating repos

### DIFF
--- a/manifests/epel.pp
+++ b/manifests/epel.pp
@@ -21,6 +21,18 @@ class rpmrepos::epel ($testing           = '0',
 
     anchor {'rpmrepos::epel::begin':} ->
 
+    file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}":
+      ensure => present,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+      source => "puppet:///modules/rpmrepos/RPM-GPG-KEY-EPEL-${::os_maj_version}",
+    } ->
+
+    rpmrepos::rpm_gpg_key{ "EPEL-${::os_maj_version}":
+      path => "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}"
+    } ->    
+
     yumrepo { 'epel-testing':
       baseurl        => "http://download.fedora.redhat.com/pub/epel/testing/${::os_maj_version}/${::architecture}",
       failovermethod => 'priority',
@@ -79,18 +91,6 @@ class rpmrepos::epel ($testing           = '0',
       gpgcheck       => '1',
       gpgkey         => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}",
       descr          => "Extra Packages for Enterprise Linux ${::os_maj_version} - ${::architecture} - Source"
-    } ->
-
-    file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}":
-      ensure => present,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
-      source => "puppet:///modules/rpmrepos/RPM-GPG-KEY-EPEL-${::os_maj_version}",
-    } ->
-
-    rpmrepos::rpm_gpg_key{ "EPEL-${::os_maj_version}":
-      path => "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${::os_maj_version}"
     } ->
 
     anchor {'rpmrepos::epel::end':}

--- a/manifests/rpmforge.pp
+++ b/manifests/rpmforge.pp
@@ -16,6 +16,18 @@ class rpmrepos::rpmforge ($testing = '0',
 
     anchor {'rpmrepos::rpmforge::begin':} ->
 
+    file { '/etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag':
+        ensure => present,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0644',
+        source => 'puppet:///modules/rpmrepos/RPM-GPG-KEY-rpmforge-dag',
+    } ->
+
+    rpmrepos::rpm_gpg_key{ 'rpmforge-dag':
+        path => '/etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag',
+    } ->    
+
     yumrepo { 'rpmforge':
         baseurl     => "http://apt.sw.be/redhat/el${::os_maj_version}/en/${::architecture}/rpmforge/",
         mirrorlist  => "http://apt.sw.be/redhat/el${::os_maj_version}/en/mirrors-rpmforge",
@@ -45,18 +57,6 @@ class rpmrepos::rpmforge ($testing = '0',
         gpgcheck    => 1,
         gpgkey      => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag',
         descr       => "Rpmforge - ${::os_maj_version} - Testing - ${::architecture}"
-    } ->
-
-    file { '/etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag':
-        ensure => present,
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0644',
-        source => 'puppet:///modules/rpmrepos/RPM-GPG-KEY-rpmforge-dag',
-    } ->
-
-    rpmrepos::rpm_gpg_key{ 'rpmforge-dag':
-        path => '/etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag',
     } ->
 
     anchor {'rpmrepos::rpmforge::end':}


### PR DESCRIPTION
Another forge module (https://github.com/jonbrouse/puppet-couchdb) creates a dependency on epel: 
```
class couchdb::package {
    package { 'couchdb':
      ensure  => installed,
      require => Yumrepo[ 'epel' ], 
  }
}
```
The repo resource is created before the keys are imported, so the install fails with:
```
GPG key retrieval failed: [Errno 14] Could not open/read file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
```
The key is imported later in the run, and the next run works.  This moves the GPG import as a prereq to defining the repo.